### PR TITLE
update

### DIFF
--- a/src/View/ImageFusion/BaseViewerGUI.py
+++ b/src/View/ImageFusion/BaseViewerGUI.py
@@ -1,4 +1,5 @@
-from PySide6 import QtWidgets
+import contextlib
+from PySide6 import QtWidgets, QtGui
 from src.View.mainpage.DicomView import DicomView, GraphicsScene
 from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
 
@@ -6,23 +7,26 @@ from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
 class BaseFusionView(DicomView):
     def __init__(self, slice_view, roi_color=None, iso_color=None, cut_line_color=None):
         self.slice_view = slice_view
+        super().__init__(roi_color, iso_color, cut_line_color)
 
         self.translation_menu = TranslateRotateMenu()
         self.translation_menu.set_offset_changed_callback(self.update_overlay_offset)
-        super().__init__(roi_color, iso_color, cut_line_color)
+        self.overlay_item = None
+        self.overlay_images = None
+        self.base_item = None
         self.update_view()
 
     def image_display(self, overlay_image=None):
         """
-            Update the image to be displayed on the DICOM View.
-            If overlay_image is provided, use it as the overlay for this view.
-            """
-
+                Update the image to be displayed on the DICOM View.
+                If overlay_image is provided, use it as the overlay for this view.
+                Also ensures overlay_item is created and positioned correctly.
+                """
         slider_id = self.slider.value()
 
         if overlay_image is not None:
             image = overlay_image
-        elif hasattr(self, "overlay_images"):
+        elif self.overlay_images is not None:
             if 0 <= slider_id < len(self.overlay_images):
                 image = self.overlay_images[slider_id]
             else:
@@ -36,8 +40,31 @@ class BaseFusionView(DicomView):
             else:
                 return
 
-        label = QtWidgets.QGraphicsPixmapItem(image)
-        self.scene = GraphicsScene(label, self.horizontal_view, self.vertical_view)
+        # Update or create the base image item
+        if self.base_item is None:
+            self.base_item = QtWidgets.QGraphicsPixmapItem(image)
+            self.scene.addItem(self.base_item)
+        else:
+            self.base_item.setPixmap(image)
+
+            # Update or create the overlay item
+        if self.overlay_images is not None and 0 <= slider_id < len(self.overlay_images):
+            overlay_pixmap = self.overlay_images[slider_id]
+            if self.overlay_item is None:
+                self.overlay_item = QtWidgets.QGraphicsPixmapItem(overlay_pixmap)
+                self.overlay_item.setZValue(1)  # Ensure overlay is below cut lines
+                offset = getattr(self, "overlay_offset", (0, 0))
+                self.overlay_item.setPos(offset[0], offset[1])
+                self.scene.addItem(self.overlay_item)
+            else:
+                self.overlay_item.setPixmap(overlay_pixmap)
+                offset = getattr(self, "overlay_offset", (0, 0))
+                self.overlay_item.setPos(offset[0], offset[1])
+        else:
+            self.overlay_item = None
+
+
+
 
     def roi_display(self):
         """
@@ -68,17 +95,16 @@ class BaseFusionView(DicomView):
         """
         Repaint the overlay image with the applied offset.
         """
-        if hasattr(self, "overlay_images"):
+        if self.overlay_images is not None:
             slider_id = self.slider.value()
             if slider_id >= len(self.overlay_images):
                 return
-            image = self.overlay_images[slider_id]
 
-            if hasattr(self, "overlay_item"):
-                # just update position
+            # Only move the overlay_item if it exists
+            if hasattr(self, "overlay_item") and self.overlay_item is not None:
                 self.overlay_item.setPos(self.overlay_offset[0], self.overlay_offset[1])
-            else:
-                # first-time creation
-                self.overlay_item = QtWidgets.QGraphicsPixmapItem(image)
-                self.overlay_item.setPos(self.overlay_offset[0], self.overlay_offset[1])
-                self.scene.addItem(self.overlay_item)
+                self.scene.update()
+                if hasattr(self, "viewport"):
+                    self.viewport().update()
+
+

--- a/src/View/ImageFusion/BaseViewerGUI.py
+++ b/src/View/ImageFusion/BaseViewerGUI.py
@@ -1,0 +1,84 @@
+from PySide6 import QtWidgets
+from src.View.mainpage.DicomView import DicomView, GraphicsScene
+from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
+
+
+class BaseFusionView(DicomView):
+    def __init__(self, slice_view, roi_color=None, iso_color=None, cut_line_color=None):
+        self.slice_view = slice_view
+
+        self.translation_menu = TranslateRotateMenu()
+        self.translation_menu.set_offset_changed_callback(self.update_overlay_offset)
+        super().__init__(roi_color, iso_color, cut_line_color)
+        self.update_view()
+
+    def image_display(self, overlay_image=None):
+        """
+            Update the image to be displayed on the DICOM View.
+            If overlay_image is provided, use it as the overlay for this view.
+            """
+
+        slider_id = self.slider.value()
+
+        if overlay_image is not None:
+            image = overlay_image
+        elif hasattr(self, "overlay_images"):
+            if 0 <= slider_id < len(self.overlay_images):
+                image = self.overlay_images[slider_id]
+            else:
+                return
+        else:
+            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
+            if pixmaps is None:
+                return  # Prevent NoneType subscriptable error
+            if 0 <= slider_id < len(pixmaps):
+                image = pixmaps[slider_id]
+            else:
+                return
+
+        label = QtWidgets.QGraphicsPixmapItem(image)
+        self.scene = GraphicsScene(label, self.horizontal_view, self.vertical_view)
+
+    def roi_display(self):
+        """
+        Display ROI structures on the DICOM Image.
+        """
+        slider_id = self.slider.value()
+        curr_slice = self.patient_dict_container.get("dict_uid")[slider_id]
+
+        selected_rois = self.patient_dict_container.get("selected_rois")
+        rois = self.patient_dict_container.get("rois")
+        selected_rois_name = []
+        selected_rois_name.extend(rois[roi]['name'] for roi in selected_rois)
+        for roi in selected_rois:
+            roi_name = rois[roi]['name']
+            polygons = self.patient_dict_container.get("dict_polygons_axial")[
+                roi_name][curr_slice]
+            super().draw_roi_polygons(roi, polygons)
+
+    def update_overlay_offset(self, offset):
+        """
+        Apply translation to the overlay image.
+        offset: tuple (x, y)
+        """
+        self.overlay_offset = offset
+        self.refresh_overlay()
+
+    def refresh_overlay(self):
+        """
+        Repaint the overlay image with the applied offset.
+        """
+        if hasattr(self, "overlay_images"):
+            slider_id = self.slider.value()
+            if slider_id >= len(self.overlay_images):
+                return
+            image = self.overlay_images[slider_id]
+
+            if hasattr(self, "overlay_item"):
+                # just update position
+                self.overlay_item.setPos(self.overlay_offset[0], self.overlay_offset[1])
+            else:
+                # first-time creation
+                self.overlay_item = QtWidgets.QGraphicsPixmapItem(image)
+                self.overlay_item.setPos(self.overlay_offset[0], self.overlay_offset[1])
+                self.scene.addItem(self.overlay_item)

--- a/src/View/ImageFusion/ImageFusionAxialView.py
+++ b/src/View/ImageFusion/ImageFusionAxialView.py
@@ -179,7 +179,7 @@ class ImageFusionAxialView(DicomView):
             slider_id = self.slider.value()
             image = self.overlay_images[slider_id]
         else:
-            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
             if pixmaps is None:
                 return  # Prevent NoneType subscriptable error
             slider_id = self.slider.value()

--- a/src/View/ImageFusion/ImageFusionAxialView.py
+++ b/src/View/ImageFusion/ImageFusionAxialView.py
@@ -220,17 +220,15 @@ class ImageFusionAxialView(DicomView):
 
         if hasattr(dataset, 'PatientPosition'):
             patient_pos = dataset['PatientPosition'].value
-            self.label_patient_pos.setText(
-                "Patient Position: %s" % (str(patient_pos)))
+            self.label_patient_pos.setText(f"Patient Position: {str(patient_pos)}")
 
         # Update labels
         self.label_image_id.setText(
-            "Image: %s / %s" % (str(self.current_slice_number),
-                                str(total_slices)))
-        self.label_image_pos.setText("Position: %s mm" % (str(slice_pos)))
-        self.label_wl.setText("W/L: %s/%s" % (str(window), str(level)))
-        self.label_image_size.setText(
-            "Image Size: %sx%spx" % (str(row_img), str(col_img)))
+            f"Image: {str(self.current_slice_number)} / {total_slices}"
+        )
+        self.label_image_pos.setText(f"Position: {str(slice_pos)} mm")
+        self.label_wl.setText(f"W/L: {str(window)}/{str(level)}")
+        self.label_image_size.setText(f"Image Size: {str(row_img)}x{str(col_img)}px")
         self.label_zoom.setText(
             "Zoom: " + "{:.2f}".format(self.zoom * 100) + "%")
 
@@ -244,9 +242,7 @@ class ImageFusionAxialView(DicomView):
         selected_rois = self.patient_dict_container.get("selected_rois")
         rois = self.patient_dict_container.get("rois")
         selected_rois_name = []
-        for roi in selected_rois:
-            selected_rois_name.append(rois[roi]['name'])
-
+        selected_rois_name.extend(rois[roi]['name'] for roi in selected_rois)
         for roi in selected_rois:
             roi_name = rois[roi]['name']
             polygons = self.patient_dict_container.get("dict_polygons_axial")[

--- a/src/View/ImageFusion/ImageFusionCoronalView.py
+++ b/src/View/ImageFusion/ImageFusionCoronalView.py
@@ -24,7 +24,7 @@ class ImageFusionCoronalView(DicomView):
             slider_id = self.slider.value()
             image = self.overlay_images[slider_id]
         else:
-            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
             if pixmaps is None:
                 return  # Prevent NoneType subscriptable error
             slider_id = self.slider.value()
@@ -44,9 +44,7 @@ class ImageFusionCoronalView(DicomView):
         selected_rois = self.patient_dict_container.get("selected_rois")
         rois = self.patient_dict_container.get("rois")
         selected_rois_name = []
-        for roi in selected_rois:
-            selected_rois_name.append(rois[roi]['name'])
-
+        selected_rois_name.extend(rois[roi]['name'] for roi in selected_rois)
         for roi in selected_rois:
             roi_name = rois[roi]['name']
             polygons = self.patient_dict_container.get("dict_polygons_axial")[

--- a/src/View/ImageFusion/ImageFusionCoronalView.py
+++ b/src/View/ImageFusion/ImageFusionCoronalView.py
@@ -1,52 +1,6 @@
-from PySide6 import QtWidgets, QtGui
-from src.View.mainpage.DicomView import DicomView, GraphicsScene
+from src.View.ImageFusion.BaseViewerGUI import BaseFusionView
 
 
-class ImageFusionCoronalView(DicomView):
-    def __init__(self,
-                 roi_color=None,
-                 iso_color=None,
-                 cut_line_color=None):
-        self.slice_view = 'coronal'
-        super(ImageFusionCoronalView, self).__init__(roi_color,
-                                                     iso_color,
-                                                     cut_line_color)
-        self.update_view()
-
-    def image_display(self, overlay_image=None):
-        """
-        Update the image to be displayed on the DICOM View.
-        If overlay_image is provided, use it as the overlay for this view.
-        """
-        if overlay_image is not None:
-            image = overlay_image
-        elif hasattr(self, "overlay_images"):
-            slider_id = self.slider.value()
-            image = self.overlay_images[slider_id]
-        else:
-            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
-            if pixmaps is None:
-                return  # Prevent NoneType subscriptable error
-            slider_id = self.slider.value()
-            image = pixmaps[slider_id]
-
-        label = QtWidgets.QGraphicsPixmapItem(image)
-        self.scene = GraphicsScene(
-            label, self.horizontal_view, self.vertical_view)
-
-    def roi_display(self):
-        """
-        Display ROI structures on the DICOM Image.
-        """
-        slider_id = self.slider.value()
-        curr_slice = self.patient_dict_container.get("dict_uid")[slider_id]
-
-        selected_rois = self.patient_dict_container.get("selected_rois")
-        rois = self.patient_dict_container.get("rois")
-        selected_rois_name = []
-        selected_rois_name.extend(rois[roi]['name'] for roi in selected_rois)
-        for roi in selected_rois:
-            roi_name = rois[roi]['name']
-            polygons = self.patient_dict_container.get("dict_polygons_axial")[
-                roi_name][curr_slice]
-            super().draw_roi_polygons(roi, polygons)
+class ImageFusionCoronalView(BaseFusionView):
+    def __init__(self, roi_color=None, iso_color=None, cut_line_color=None):
+        super().__init__('coronal', roi_color, iso_color, cut_line_color)

--- a/src/View/ImageFusion/ImageFusionSagittalView.py
+++ b/src/View/ImageFusion/ImageFusionSagittalView.py
@@ -30,7 +30,7 @@ class ImageFusionSagittalView(DicomView):
             slider_id = self.slider.value()
             image = self.overlay_images[slider_id]
         else:
-            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
             if pixmaps is None:
                 return  # Prevent NoneType subscriptable error
             slider_id = self.slider.value()

--- a/src/View/ImageFusion/ImageFusionSagittalView.py
+++ b/src/View/ImageFusion/ImageFusionSagittalView.py
@@ -1,60 +1,7 @@
-from PySide6 import QtWidgets
-from src.View.mainpage.DicomView import DicomView, GraphicsScene
+from src.View.ImageFusion.BaseViewerGUI import BaseFusionView
 
 
-class ImageFusionSagittalView(DicomView):
-    def __init__(self,
-                 roi_color=None,
-                 iso_color=None,
-                 metadata_formatted=False,
-                 cut_line_color=None):
-        """
-        metadata_formatted: whether the metadata needs to be formatted 
-        (only metadata in the four view need to be formatted)
-        """
-        self.slice_view = 'sagittal'
-        super(ImageFusionSagittalView, self).__init__(roi_color,
-                                                      iso_color,
-                                                      cut_line_color)
 
-        self.update_view()
-
-    def image_display(self, overlay_image=None):
-        """
-        Update the image to be displayed on the DICOM View.
-        If overlay_image is provided, use it as the overlay for this view.
-        """
-        if overlay_image is not None:
-            image = overlay_image
-        elif hasattr(self, "overlay_images"):
-            slider_id = self.slider.value()
-            image = self.overlay_images[slider_id]
-        else:
-            pixmaps = self.patient_dict_container.get(f"color_{self.slice_view}")
-            if pixmaps is None:
-                return  # Prevent NoneType subscriptable error
-            slider_id = self.slider.value()
-            image = pixmaps[slider_id]
-
-        label = QtWidgets.QGraphicsPixmapItem(image)
-        self.scene = GraphicsScene(
-            label, self.horizontal_view, self.vertical_view)
-
-    def roi_display(self):
-        """
-        Display ROI structures on the DICOM Image.
-        """
-        slider_id = self.slider.value()
-        curr_slice = self.patient_dict_container.get("dict_uid")[slider_id]
-
-        selected_rois = self.patient_dict_container.get("selected_rois")
-        rois = self.patient_dict_container.get("rois")
-        selected_rois_name = []
-        for roi in selected_rois:
-            selected_rois_name.append(rois[roi]['name'])
-
-        for roi in selected_rois:
-            roi_name = rois[roi]['name']
-            polygons = self.patient_dict_container.get("dict_polygons_axial")[
-                roi_name][curr_slice]
-            super().draw_roi_polygons(roi, polygons)
+class ImageFusionSagittalView(BaseFusionView):
+    def __init__(self, roi_color=None, iso_color=None, cut_line_color=None):
+        super().__init__('sagittal', roi_color, iso_color, cut_line_color)

--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -12,31 +12,84 @@ class ManualFusionLoader(QtCore.QObject):
 
     def load(self, interrupt_flag=None, progress_callback=None):
         try:
-            # Optionally, emit progress if callback is provided
-            if progress_callback is not None:
-                progress_callback.emit(("Loading fixed image...", 10))
-            # Load fixed (base) and moving (overlay) images as SimpleITK
-            patient_dict_container = PatientDictContainer()
-            fixed_filepaths = []
-            for i in range(len(patient_dict_container.filepaths)):
-                try:
-                    fixed_filepaths.append(patient_dict_container.filepaths[i])
-                except KeyError:
-                    continue
-
-            moving_filepaths = self.selected_files
-
-            fixed_image = sitk.ReadImage(fixed_filepaths)
-            if progress_callback is not None:
-                progress_callback.emit(("Loading overlay image...", 50))
-            moving_image = sitk.ReadImage(moving_filepaths)
-
-            if progress_callback is not None:
-                progress_callback.emit(("Finished loading images", 100))
-
-            self.signal_loaded.emit((True, {
-                "fixed_image": fixed_image,
-                "moving_image": moving_image
-            }))
+            self._extracted_from_load_4(progress_callback)
         except Exception as e:
+            if progress_callback is not None:
+                progress_callback.emit(("Error loading images", e))
             self.signal_error.emit((False, e))
+
+    # TODO Rename this here and in `load`
+    def _extracted_from_load_4(self, progress_callback):
+        # Progress: loading fixed image
+        if progress_callback is not None:
+            progress_callback.emit(("Loading fixed image...", 10))
+
+        # Gather fixed filepaths
+        patient_dict_container = PatientDictContainer()
+        fixed_filepaths = [
+            patient_dict_container.filepaths[i]
+            for i in range(len(patient_dict_container.filepaths))
+            if i in patient_dict_container.filepaths
+        ]
+
+        # Load fixed image as a sorted DICOM series
+        fixed_image = self._load_dicom_series(fixed_filepaths)
+        if progress_callback is not None:
+            progress_callback.emit(("Loading overlay image...", 50))
+
+        # Load moving image as a sorted DICOM series
+        moving_image = self._load_dicom_series(self.selected_files)
+
+        if progress_callback is not None:
+            progress_callback.emit(("Finished loading images", 100))
+
+        # Emit loaded images
+        self.signal_loaded.emit((True, {
+            "fixed_image": fixed_image,
+            "moving_image": moving_image
+        }))
+
+    def _load_dicom_series(self, filepaths):
+        """
+        Loads a DICOM series robustly for image fusion.
+
+        - Filters out files that are not valid CT DICOM images.
+        - Sorts the valid files by their Z position (ImagePositionPatient tag).
+        - Reads the sorted series into a 3D SimpleITK image.
+
+        Args:
+            filepaths (list): List of file paths to DICOM files.
+
+        Returns:
+            SimpleITK.Image: The loaded 3D image volume.
+        """
+        if not filepaths:
+            raise ValueError("No DICOM files provided.")
+
+        # Collect (filepath, z) for valid CT files in a single pass
+        valid_files_with_z = []
+        for f in filepaths:
+            try:
+                img = sitk.ReadImage(f)
+                if img.HasMetaDataKey("0008|0060"):
+                    modality = img.GetMetaData("0008|0060")
+                    if modality.upper() == "CT":
+                        z = 0.0
+                        if img.HasMetaDataKey("0020|0032"):
+                            ipp = img.GetMetaData("0020|0032").split("\\")
+                            z = float(ipp[2])
+                        valid_files_with_z.append((f, z))
+            except Exception:
+                continue
+
+        if not valid_files_with_z:
+            raise ValueError("No valid CT DICOM files found.")
+
+        # Sort by Z position
+        valid_files_with_z.sort(key=lambda x: x[1])
+        sorted_files = [f for f, _ in valid_files_with_z]
+
+        # Read the sorted series into a 3D image
+        reader = sitk.ImageSeriesReader()
+        reader.SetFileNames(sorted_files)
+        return reader.Execute()

--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -67,6 +67,9 @@ class ManualFusionLoader(QtCore.QObject):
             raise ValueError("No DICOM files provided.")
 
         # Collect (filepath, z) for valid CT files in a single pass
+        import logging
+        logger = logging.getLogger(__name__)
+
         valid_files_with_z = []
         for f in filepaths:
             try:
@@ -79,7 +82,8 @@ class ManualFusionLoader(QtCore.QObject):
                             ipp = img.GetMetaData("0020|0032").split("\\")
                             z = float(ipp[2])
                         valid_files_with_z.append((f, z))
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Failed to process DICOM file '{f}': {e}", exc_info=True)
                 continue
 
         if not valid_files_with_z:

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -27,8 +27,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             slider.setMinimum(-100)
             slider.setMaximum(100)
             slider.setValue(0)
-            slider.valueChanged.connect(lambda value, idx=i:
-                                        self.on_offset_change(idx, value))
+            slider.valueChanged.connect(self._make_offset_change_handler(i))
             value_label = QtWidgets.QLabel("0 px")
             value_label.setFixedWidth(50)
 
@@ -103,6 +102,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             Args:
                 offsets: A tuple or list containing the new x and y offset values.
         """
+
         for i in range(2):
             self.translate_sliders[i].blockSignals(True)
             self.translate_sliders[i].setValue(offsets[i])
@@ -119,3 +119,6 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             slider.setValue(0)
             label.setText("0 px")
             slider.blockSignals(False)
+
+    def _make_offset_change_handler(self, idx):
+        return lambda value: self.on_offset_change(idx, value)

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -10,13 +10,16 @@ class TranslateRotateMenu(QtWidgets.QWidget):
 
     def __init__(self, _back_callback=None):
         super().__init__()
+        self.offset_changed_callback = None
+
         layout = QtWidgets.QVBoxLayout()
 
         # Translate section
         layout.addSpacing(4)
         layout.addWidget(QtWidgets.QLabel("Translate:"), alignment=Qt.AlignLeft)
         self.translate_sliders = []
-        for axis in ['LR', 'PA', 'IS']:
+        self.translate_labels = []
+        for i, axis in enumerate(['x', 'y']):
             hbox = QtWidgets.QHBoxLayout()
             label = QtWidgets.QLabel(axis)
             label.setFixedWidth(30)
@@ -24,10 +27,18 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             slider.setMinimum(-100)
             slider.setMaximum(100)
             slider.setValue(0)
+            slider.valueChanged.connect(lambda value, idx=i:
+                                        self.on_offset_change(idx, value))
+            value_label = QtWidgets.QLabel("0 px")
+            value_label.setFixedWidth(50)
+
             hbox.addWidget(label)
             hbox.addWidget(slider)
+            hbox.addWidget(value_label)
             layout.addLayout(hbox)
             self.translate_sliders.append(slider)
+            self.translate_labels.append(value_label)
+
 
         # Rotate section
         layout.addSpacing(8)
@@ -57,3 +68,54 @@ class TranslateRotateMenu(QtWidgets.QWidget):
 
         layout.addStretch(1)
         self.setLayout(layout)
+
+    def on_offset_change(self, axis_index, value):
+        """
+            When a slider value changes, this method collects the current x and y offsets and
+            calls the registered offset_changed_callback with the new values.
+
+            Args:
+                axis_index: The index of the axis that was changed (0 for x, 1 for y).
+                value: The new value of the changed slider.
+        """
+        self.translate_labels[axis_index].setText(f"{value} px")
+        if self.offset_changed_callback:
+            x = self.translate_sliders[0].value()
+            y = self.translate_sliders[1].value()
+            self.offset_changed_callback((x, y))
+
+    def set_offset_changed_callback(self, callback):
+        """
+                This method allows external code to register a callback that will be
+                invoked with the new (x, y) offset when a slider is adjusted.
+
+                Args:
+                    callback: A function that takes a tuple or list representing
+                    the new (x, y) offset.
+                """
+        self.offset_changed_callback = callback
+
+    def set_offsets(self, offsets):
+        """
+            This method updates the slider positions for the x and y axes without
+            emitting value changed signals.
+
+            Args:
+                offsets: A tuple or list containing the new x and y offset values.
+        """
+        for i in range(2):
+            self.translate_sliders[i].blockSignals(True)
+            self.translate_sliders[i].setValue(offsets[i])
+            self.translate_labels[i].setText(f"{offsets[i]} px")
+            self.translate_sliders[i].blockSignals(False)
+
+    def reset_trans(self):
+        """
+                This method sets each translation slider to zero and updates the
+                corresponding label to "0 px".
+                """
+        for slider, label in zip(self.sliders, self.labels):
+            slider.blockSignals(True)
+            slider.setValue(0)
+            label.setText("0 px")
+            slider.blockSignals(False)

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -38,6 +38,8 @@ from src.Controller.PathHandler import resource_path
 from src.constants import INITIAL_FOUR_VIEW_ZOOM
 from src._version import __version__
 
+
+
 class UIMainWindow:
     """
     The central class responsible for initializing most of the values stored
@@ -483,11 +485,12 @@ class UIMainWindow:
             self.image_fusion_view_sagittal.slider.valueChanged.connect(
                 lambda: self.image_fusion_view_sagittal.image_display())
 
-            # Initial display
+            # # Initial display
             self.image_fusion_view_axial.image_display()
             self.image_fusion_view_coronal.image_display()
             self.image_fusion_view_sagittal.image_display()
 
+        #TODO Fix duplicate
         # Rescale the size of the scenes inside the 3-slice views
         self.image_fusion_view_axial.zoom = INITIAL_FOUR_VIEW_ZOOM
         self.image_fusion_view_sagittal.zoom = INITIAL_FOUR_VIEW_ZOOM
@@ -522,6 +525,9 @@ class UIMainWindow:
         # Add Image Fusion Tab
         self.right_panel.addTab(self.image_fusion_view, "Image Fusion")
         self.right_panel.setCurrentWidget(self.image_fusion_view)
+
+        # Add the panel to the fusion options tab (or wherever you want in the GUI)
+        # self.fusion_options_tab.layout().addWidget(self.translation_control_panel)
 
         # Update the Add On Option GUI
         self.add_on_options_controller.update_ui()

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -445,7 +445,22 @@ class UIMainWindow:
 
         # --- Fusion Options Tab with Translate/Rotate Menu ---
         from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
-        self.fusion_options_tab = TranslateRotateMenu(lambda: None)
+        # Create a single menu for all views
+        self.fusion_options_tab = TranslateRotateMenu()
+
+        # Define a callback that updates all three views
+        def update_all_views(offset):
+            print(f"[FusionOptions] Updating all views with offset: {offset}")
+            for view in [
+                # self.image_fusion_view_axial,
+                self.image_fusion_view_sagittal,
+                self.image_fusion_view_coronal,
+            ]:
+                view.image_display()
+                view.update_overlay_offset(offset)
+
+        self.fusion_options_tab.set_offset_changed_callback(update_all_views)
+
         self.left_panel.addTab(self.fusion_options_tab, "Fusion Options")
         self.left_panel.setCurrentWidget(self.fusion_options_tab)
 

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -424,9 +424,8 @@ class UIMainWindow:
         moving_dict_container = MovingDictContainer()
 
         # Only check for modality if dataset is not None
-        if moving_dict_container.dataset is not None and moving_dict_container.has_modality("rtss"):
-            if len(self.structures_tab.rois.items()) == 0:
-                self.structures_tab.update_ui(moving=True)
+        if moving_dict_container.dataset is not None and moving_dict_container.has_modality("rtss") and len(self.structures_tab.rois.items()) == 0:
+            self.structures_tab.update_ui(moving=True)
 
         self.image_fusion_single_view = ImageFusionAxialView()
 


### PR DESCRIPTION
got the load image error down from maximum nonuniformity: 1754.5 to maximum nonuniformity: 0.00997275

because the file was mixed with CT + RTSTRUCT + RTDOSE it was missing slices and loading incorrectly

## Summary by Sourcery

Improve robustness of DICOM series loading in manual fusion by filtering for CT volumes, sorting slices by position, and handling mixed modality files; refactor loader methods and apply minor view code cleanups

Bug Fixes:
- Fix missing CT slices when loading mixed DICOM series (CT + RTSTRUCT + RTDOSE)

Enhancements:
- Extract image loading logic into helper methods in ManualFusionLoader
- Filter out non-CT files and sort valid files by Z position before reading series
- Enhance progress reporting and error emission during image loading

Chores:
- Replace string concatenation with f-strings in view classes
- Simplify list building and conditional statements in multiple view files