### PR TITLE
Redoing the PR

### DIFF
--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -1,8 +1,11 @@
+import itertools
 from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import QFileDialog, QMessageBox
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from src.View.ImageFusion.TransformMatrixDialog import TransformMatrixDialog
 from src.Controller.PathHandler import resource_path
+import logging
 
 
 def get_color_pair_from_text(text):
@@ -20,6 +23,7 @@ def get_color_pair_from_text(text):
             return "Red", "Cyan", True
         case _:
             return "Purple", "Green", True
+
 
 class TranslateRotateMenu(QtWidgets.QWidget):
     """
@@ -119,7 +123,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         self.mouse_mode_group.addButton(self.mouse_translate_btn)
         self.mouse_mode_group.addButton(self.mouse_rotate_btn)
 
-        # Track last clicked button for "toggle off" 
+        # Track last clicked button for "toggle off"
         self._last_checked_button = None
 
         def on_mouse_mode_btn_clicked(btn):
@@ -142,7 +146,6 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             if self.mouse_mode_changed_callback:
                 self.mouse_mode_changed_callback(self.mouse_mode)
 
-
         self.mouse_translate_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_translate_btn))
         self.mouse_rotate_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_rotate_btn))
 
@@ -158,9 +161,9 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             label.setFixedWidth(30)
             slider = QtWidgets.QSlider(Qt.Horizontal)
             slider.setMinimum(-1800)  # -180.0 deg (in 0.1 deg steps)
-            slider.setMaximum(1800)   # +180.0 deg (in 0.1 deg steps)
+            slider.setMaximum(1800)  # +180.0 deg (in 0.1 deg steps)
             slider.setValue(0)
-            slider.setSingleStep(1)   # 0.1 deg per step
+            slider.setSingleStep(1)  # 0.1 deg per step
             slider.valueChanged.connect(self._make_rotation_change_handler(i))
             value_label = QtWidgets.QLabel("0°")
             value_label.setFixedWidth(50)
@@ -185,6 +188,15 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         reset_btn.setToolTip("Reset all translation and rotation to zero")
         reset_btn.clicked.connect(self.reset_transform)
         layout.addWidget(reset_btn)
+
+        # Add Save/Load buttons
+        save_button = QtWidgets.QPushButton("Save Fusion State")
+        load_button = QtWidgets.QPushButton("Load Fusion State")
+        save_button.clicked.connect(self.save_fusion_state)
+        load_button.clicked.connect(self.load_fusion_state)
+        # Add to layout (assume self.layout() is a QVBoxLayout)
+        layout.addWidget(save_button)
+        layout.addWidget(load_button)
 
         # Show Transform Matrix Button
         show_matrix_btn = QtWidgets.QPushButton("Show Transform Matrix")
@@ -294,7 +306,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         Called when a rotation slider value changes.
         """
         # Show value in degrees (float, 1 decimal)
-        self.rotate_labels[axis_index].setText(f"{value/10.0:.1f}°")
+        self.rotate_labels[axis_index].setText(f"{value / 10.0:.1f}°")
         if self.rotation_changed_callback:
             rx = self.rotate_sliders[0].value() / 10.0
             ry = self.rotate_sliders[1].value() / 10.0
@@ -398,3 +410,248 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         self._matrix_dialog.show()
         self._matrix_dialog.raise_()
         self._matrix_dialog.activateWindow()
+
+    def save_fusion_state(self):
+        """
+        Save the current fusion transform as a DICOM Spatial Registration Object (SRO).
+
+        This function creates a standards-compliant DICOM SRO containing the 4x4 transformation matrix
+        for the moving image overlay, referencing the fixed and moving images. The user is prompted
+        to select the save location and filename for the DICOM file.
+
+        Returns:
+            None
+        """
+        import numpy as np
+
+        vtk_engine = self._get_vtk_engine_callback() if hasattr(self,
+                                                                "_get_vtk_engine_callback") and self._get_vtk_engine_callback else None
+        if vtk_engine is None:
+            QMessageBox.warning(self, "Error", "No VTK engine found.")
+            logging.error("No VTK engine found in save_fusion_state")
+            return
+
+        # Gather the 4x4 transform matrix
+        matrix = None
+        if hasattr(vtk_engine, "transform"):
+            m = vtk_engine.transform.GetMatrix()
+            matrix = np.array([[m.GetElement(i, j) for j in range(4)] for i in range(4)], dtype=np.float32)
+        else:
+            QMessageBox.warning(self, "Error", "No transform matrix found.")
+            logging.error("No transform matrix found")
+            return
+
+        # Print translation and rotation being saved
+        translation = [vtk_engine._tx, vtk_engine._ty, vtk_engine._tz]
+        rotation = [vtk_engine._rx, vtk_engine._ry, vtk_engine._rz]
+
+        ds = self._create_spatial_registration_dicom(matrix, translation, rotation, vtk_engine)
+
+        # Save as DICOM SRO
+        filename, _ = QFileDialog.getSaveFileName(self, "Save Spatial Registration (SRO)", "transform.dcm",
+                                                  "DICOM Files (*.dcm)")
+        if filename:
+            ds.save_as(filename)
+            QMessageBox.information(self, "Saved", f"Spatial Registration (SRO) saved to {filename}")
+
+    def _create_spatial_registration_dicom(self, matrix, translation, rotation, vtk_engine):
+        """
+        Create a DICOM Spatial Registration Object (SRO) dataset with the given transform.
+
+        Args:
+            matrix: 4x4 numpy array representing the transformation matrix.
+            translation: List of translation values [tx, ty, tz].
+            rotation: List of rotation values [rx, ry, rz].
+            vtk_engine: The VTKEngine instance (for UIDs).
+
+        Returns:
+            pydicom FileDataset representing the SRO.
+        """
+        import pydicom
+        from pydicom.dataset import FileDataset, Dataset
+        from pydicom.uid import generate_uid
+        import datetime
+
+        # Get UIDs for fixed and moving images from VTKEngine if available
+        fixed_series_uid = getattr(vtk_engine, "fixed_series_uid", "1.2.3.4.5.6.7.8.1")
+        fixed_image_uid = getattr(vtk_engine, "fixed_image_uid", "1.2.3.4.5.6.7.8.1.1")
+        moving_series_uid = getattr(vtk_engine, "moving_series_uid", "1.2.3.4.5.6.7.8.2")
+        moving_image_uid = getattr(vtk_engine, "moving_image_uid", "1.2.3.4.5.6.7.8.2.1")
+
+        # Create a minimal DICOM SRO dataset
+        file_meta = pydicom.Dataset()
+        file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.66.1"  # Spatial Registration Storage
+        file_meta.MediaStorageSOPInstanceUID = generate_uid()
+        file_meta.ImplementationClassUID = generate_uid()
+
+        ds = FileDataset("transform.dcm", {}, file_meta=file_meta, preamble=b"\0" * 128)
+        ds.is_little_endian = True
+        ds.is_implicit_VR = True
+
+        # Set required DICOM fields
+        dt = datetime.datetime.now()
+        ds.PatientName = "FUSION"
+        ds.PatientID = "FUSION"
+        ds.StudyInstanceUID = generate_uid()
+        ds.SeriesInstanceUID = generate_uid()
+        ds.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+        ds.SOPClassUID = file_meta.MediaStorageSOPClassUID
+        ds.Modality = "REG"
+        ds.StudyDate = dt.strftime('%Y%m%d')
+        ds.StudyTime = dt.strftime('%H%M%S')
+        ds.SeriesDescription = "Manual Fusion Spatial Registration"
+        ds.SeriesNumber = "1"
+        ds.InstanceNumber = "1"
+
+        # Referenced Series/Image Sequence for fixed image
+        ds.ReferencedSeriesSequence = [Dataset()]
+        ds.ReferencedSeriesSequence[0].SeriesInstanceUID = fixed_series_uid
+        ds.ReferencedSeriesSequence[0].ReferencedImageSequence = [Dataset()]
+        ds.ReferencedSeriesSequence[0].ReferencedImageSequence[
+            0].ReferencedSOPClassUID = "1.2.840.10008.5.1.4.1.1.2"  # CT Image Storage
+        ds.ReferencedSeriesSequence[0].ReferencedImageSequence[0].ReferencedSOPInstanceUID = fixed_image_uid
+
+        # Registration Sequence
+        reg = Dataset()
+        reg.MatrixRegistrationSequence = [Dataset()]
+        reg.MatrixRegistrationSequence[0].FrameOfReferenceTransformationMatrixType = "RIGID"
+        reg.MatrixRegistrationSequence[0].FrameOfReferenceTransformationMatrix = [float(v) for v in matrix.flatten()]
+        reg.MatrixRegistrationSequence[0].FrameOfReferenceTransformationComment = "Manual fusion transform"
+        reg.MatrixRegistrationSequence[0].FrameOfReferenceUID = generate_uid()
+        ds.RegistrationSequence = [reg]
+
+        # Referenced Series/Image Sequence for moving image
+        ds.RegistrationSequence[0].MatrixRegistrationSequence[0].ReferencedSeriesSequence = [Dataset()]
+        ds.RegistrationSequence[0].MatrixRegistrationSequence[0].ReferencedSeriesSequence[
+            0].SeriesInstanceUID = moving_series_uid
+        ds.RegistrationSequence[0].MatrixRegistrationSequence[0].ReferencedSeriesSequence[0].ReferencedImageSequence = [
+            Dataset()]
+        ds.RegistrationSequence[0].MatrixRegistrationSequence[0].ReferencedSeriesSequence[0].ReferencedImageSequence[
+            0].ReferencedSOPClassUID = "1.2.840.10008.5.1.4.1.1.2"
+        ds.RegistrationSequence[0].MatrixRegistrationSequence[0].ReferencedSeriesSequence[0].ReferencedImageSequence[
+            0].ReferencedSOPInstanceUID = moving_image_uid
+
+        # Save user translation/rotation as private tags for round-trip
+        ds.add_new((0x7777, 0x0020), 'LT', ",".join([str(v) for v in translation]))
+        ds.add_new((0x7777, 0x0021), 'LT', ",".join([str(v) for v in rotation]))
+
+        return ds
+
+    def load_fusion_state(self):
+        """
+        Load a fusion transform state from a DICOM Spatial Registration Object (SRO).
+
+        This function loads a previously saved 4x4 transformation matrix from a DICOM SRO file
+        (created by the Save Fusion State function) and applies it to the current fusion session.
+        The user is prompted to select the DICOM file to load.
+
+        Returns:
+            None
+        """
+        import pydicom
+        import numpy as np
+
+        vtk_engine = self._get_vtk_engine_callback() if hasattr(self,
+                                                                "_get_vtk_engine_callback") and self._get_vtk_engine_callback else None
+        if vtk_engine is None:
+            QMessageBox.warning(self, "Error", "No VTK engine found.")
+            logging.error("No VTK engine found in load_fusion_state")
+            return
+
+        filename, _ = QFileDialog.getOpenFileName(self, "Load Fusion State", "", "DICOM Files (*.dcm)")
+
+        if filename:
+            try:
+                ds = pydicom.dcmread(filename)
+            except Exception as e:
+                QMessageBox.warning(self, "Error", f"Could not read DICOM file:\n{e}")
+                logging.error(f"Could not read DICOM file:\n{e}")
+                return
+
+            # Check for Spatial Registration Object
+            if hasattr(ds, "RegistrationSequence"):
+                self._extracted_from_load_fusion_state_sro(ds, np, vtk_engine, filename)
+            elif (0x7777, 0x0010) in ds:
+                self._extracted_from_load_fusion_state_sro(ds, np, vtk_engine, filename)
+            else:
+                QMessageBox.warning(self, "Error",
+                                    "No spatial registration or transform found in DICOM file.\n"
+                                    "Please select a transform.dcm file created by the Save Fusion State function.")
+                logging.error("No spatial registration found in DICOM file.\nPlease select a transform.dcm file "
+                              "created by the Save Fusion State function.")
+
+    def _extracted_from_load_fusion_state_sro(self, ds, np, vtk_engine, filename):
+        """
+        Apply a loaded fusion transform from a DICOM SRO to the current session.
+
+        Given a DICOM dataset containing a spatial registration, this method extracts the
+        4x4 transformation matrix, applies it to the VTK engine, updates the GUI sliders,
+        and refreshes the fusion views.
+
+        Args:
+            ds: The loaded pydicom Dataset containing the SRO.
+            np: The numpy module.
+            vtk_engine: The VTKEngine instance to update.
+            filename: The filename of the loaded DICOM file.
+
+        Returns:
+            None
+        """
+        import vtk
+
+        # --- Extract 4x4 transform matrix from SRO ---
+        reg_seq = ds.RegistrationSequence[0]
+        mat_seq = reg_seq.MatrixRegistrationSequence[0]
+        matrix_flat = mat_seq.FrameOfReferenceTransformationMatrix
+        matrix = np.array(matrix_flat, dtype=np.float32).reshape((4, 4))
+
+        # For SRO, translation/rotation are not stored separately, so extract from matrix
+        # Try to load user translation/rotation if present
+        if (0x7777, 0x0020) in ds:
+            translation = [float(x) for x in ds[(0x7777, 0x0020)].value.split(",")]
+        else:
+            translation = [matrix[0, 3], matrix[1, 3], matrix[2, 3]]
+        if (0x7777, 0x0021) in ds:
+            rotation = [float(x) for x in ds[(0x7777, 0x0021)].value.split(",")]
+        else:
+            rotation = [0, 0, 0]
+
+        m = vtk.vtkMatrix4x4()
+        for i, j in itertools.product(range(4), range(4)):
+            m.SetElement(i, j, matrix[i, j])
+
+        if hasattr(vtk_engine, "transform"):
+            vtk_engine.transform.SetMatrix(m)
+            vtk_engine.reslice3d.SetResliceAxes(m)
+            vtk_engine.reslice3d.Modified()
+
+        if hasattr(vtk_engine, "set_translation"):
+            vtk_engine.set_translation(*translation)
+        if hasattr(vtk_engine, "set_rotation_deg"):
+            vtk_engine.set_rotation_deg(*rotation)
+
+        self.set_offsets(translation)
+        for i in range(3):
+            self.rotate_sliders[i].blockSignals(True)
+            self.rotate_sliders[i].setValue(int(round(rotation[i] * 10)))
+            self.rotate_labels[i].setText(f"{rotation[i]:.1f}°")
+            self.rotate_sliders[i].blockSignals(False)
+
+        if self.offset_changed_callback:
+            self.offset_changed_callback(translation)
+        if self.rotation_changed_callback:
+            self.rotation_changed_callback(tuple(rotation))
+
+        from src.View.mainpage.MainPage import UIMainWindow
+        mw = next(
+            (
+                widget
+                for widget in QtWidgets.QApplication.topLevelWidgets()
+                if isinstance(widget, UIMainWindow)
+            ),
+            None,
+        )
+        if mw is not None:
+            mw.update_views()
+
+        QMessageBox.information(self, "Loaded", f"Spatial Registration loaded from {filename}")

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -479,6 +479,12 @@ class UIMainWindow:
         # Fusion Options Tab with Translate/Rotate Menu
         self.fusion_options_tab = None
 
+        # VTKEngine integration
+        vtk_engine = None
+        # Try to get vtk_engine from loader result (set by TopLevelController)
+        if hasattr(self, "images") and isinstance(self.images, dict) and "vtk_engine" in self.images:
+            vtk_engine = self.images["vtk_engine"]
+
         if manual:
             self.fusion_options_tab = TranslateRotateMenu()
             self.fusion_options_tab.set_offset_changed_callback(update_all_views)
@@ -487,13 +493,6 @@ class UIMainWindow:
             self.fusion_options_tab.set_get_vtk_engine_callback(lambda: vtk_engine)
             self.left_panel.addTab(self.fusion_options_tab, "Fusion Options")
             self.left_panel.setCurrentWidget(self.fusion_options_tab)
-    
-
-        # VTKEngine integration
-        vtk_engine = None
-        # Try to get vtk_engine from loader result (set by TopLevelController)
-        if hasattr(self, "images") and isinstance(self.images, dict) and "vtk_engine" in self.images:
-            vtk_engine = self.images["vtk_engine"]
 
         # Pass the shared TranslateRotateMenu to all fusion views
         self.image_fusion_single_view = ImageFusionAxialView(


### PR DESCRIPTION
Redoing the PR after reverting

adds a working save / reload

## Summary by Sourcery

Add persistent save and load functionality for image fusion transforms using DICOM Spatial Registration Objects and streamline VTKEngine integration in the UI.

New Features:
- Introduce Save Fusion State button to export the current 4×4 transform as a DICOM Spatial Registration Object (SRO)
- Introduce Load Fusion State button to import a saved DICOM SRO and apply the transform to the current session

Enhancements:
- Refactor MainPage to set up VTKEngine callback for TranslateRotateMenu only once
- Add logging and user feedback for save/load operations and error conditions