### PR TITLE
Fixing Error

### DIFF
--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -32,6 +32,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
     def __init__(self, _back_callback=None):
         super().__init__()
         self.offset_changed_callback = None
+        self.mouse_mode = None
 
         layout = QtWidgets.QVBoxLayout()
 


### PR DESCRIPTION
fixing error <class 'AttributeError'> 'TranslateRotateMenu' object has no attribute 'mouse_mode'

Added a mouse mode = none in translateRotation so it is always there and will not fail

## Summary by Sourcery

Bug Fixes:
- Add a default mouse_mode initialization in TranslateRotateMenu to avoid AttributeError when accessing the attribute