### PR TITLE
Update Cut lines

### DIFF
--- a/src/View/ImageFusion/BaseViewerGUI.py
+++ b/src/View/ImageFusion/BaseViewerGUI.py
@@ -17,6 +17,8 @@ class BaseFusionView(DicomView):
         self.overlay_item = None
         self.overlay_images = None
         self.overlay_offset = (0, 0)
+        self._prev_mouse_mode = None
+        self._cut_line_active = False
 
         self.slice_view = slice_view
         self.vtk_engine = vtk_engine  # VTKEngine instance for manual fusion, or None
@@ -408,6 +410,18 @@ class BaseFusionView(DicomView):
             w = scene_size.width()
             h = scene_size.height()
             self._handle_rotate_click(x, y, w, h)
+
+    def save_and_set_mouse_mode_none(self):
+        if self.get_mouse_mode() != "none":
+            self._prev_mouse_mode = self.get_mouse_mode()
+            self._cut_line_active = True
+            self.translation_menu.set_mouse_mode("none")
+
+    def restore_prev_mouse_mode(self):
+        if self._cut_line_active and self._prev_mouse_mode is not None:
+            self.translation_menu.set_mouse_mode(self._prev_mouse_mode)
+            self._prev_mouse_mode = None
+            self._cut_line_active = False
 
     def _handle_translate_click(self, x, y, w, h):
         def axial_trans(x, y, w, h):

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -104,28 +104,23 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         self.mouse_rotate_btn.setToolTip("Enable mouse rotation mode")
         self.mouse_interrogation_btn.setToolTip(
             "Enable interrogation window mode (focus overlay in a square around mouse)")
-        self.mouse_none_btn.setToolTip("Disable mouse mode (X)")
 
         # Set icons for buttons
         translate_icon = QIcon(resource_path("res/images/btn-icons/translate_arrow_icon.png"))
         rotate_icon = QIcon(resource_path("res/images/btn-icons/rotate_arrow_icon.png"))
         interrogation_icon = QIcon(resource_path("res/images/btn-icons/interrogation_window_icon.png"))
-        none_icon = QIcon(resource_path("res/images/btn-icons/no_movement_or_window.png"))
         self.mouse_translate_btn.setIcon(translate_icon)
         self.mouse_rotate_btn.setIcon(rotate_icon)
         self.mouse_interrogation_btn.setIcon(interrogation_icon)
-        self.mouse_none_btn.setIcon(none_icon)
         self.mouse_translate_btn.setIconSize(QtCore.QSize(24, 24))
         self.mouse_rotate_btn.setIconSize(QtCore.QSize(24, 24))
         self.mouse_interrogation_btn.setIconSize(QtCore.QSize(24, 24))
-        self.mouse_none_btn.setIconSize(QtCore.QSize(24, 24))
 
         # Add stretch, buttons, stretch
         mouse_mode_hbox.addStretch(1)
         mouse_mode_hbox.addWidget(self.mouse_translate_btn)
         mouse_mode_hbox.addWidget(self.mouse_rotate_btn)
         mouse_mode_hbox.addWidget(self.mouse_interrogation_btn)
-        mouse_mode_hbox.addWidget(self.mouse_none_btn)
         mouse_mode_hbox.addStretch(1)
 
         # Insert the button row
@@ -137,7 +132,6 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         self.mouse_mode_group.addButton(self.mouse_translate_btn)
         self.mouse_mode_group.addButton(self.mouse_rotate_btn)
         self.mouse_mode_group.addButton(self.mouse_interrogation_btn)
-        self.mouse_mode_group.addButton(self.mouse_none_btn)
 
         # Track last clicked button for "toggle off"
         self._last_checked_button = None
@@ -159,8 +153,6 @@ class TranslateRotateMenu(QtWidgets.QWidget):
                     self.mouse_mode = "rotate"
                 elif btn == self.mouse_interrogation_btn:
                     self.mouse_mode = "interrogation"
-                elif btn == self.mouse_none_btn:
-                    self.mouse_mode = None
 
             # Call callback if set
             if self.mouse_mode_changed_callback:
@@ -169,7 +161,6 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         self.mouse_translate_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_translate_btn))
         self.mouse_rotate_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_rotate_btn))
         self.mouse_interrogation_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_interrogation_btn))
-        self.mouse_none_btn.clicked.connect(lambda: on_mouse_mode_btn_clicked(self.mouse_none_btn))
 
         # Rotate section
         layout.addSpacing(8)
@@ -257,8 +248,8 @@ class TranslateRotateMenu(QtWidgets.QWidget):
 
     def set_mouse_mode(self, mode):
         """
-        Set the mouse mode programmatically.
-        """
+                Set the mouse mode programmatically.
+                """
         if mode == "translate":
             self.mouse_translate_btn.setChecked(True)
             self.mouse_rotate_btn.setChecked(False)
@@ -274,9 +265,18 @@ class TranslateRotateMenu(QtWidgets.QWidget):
         else:
             self.mouse_translate_btn.setChecked(False)
             self.mouse_rotate_btn.setChecked(False)
+            self.mouse_interrogation_btn.setChecked(False)
         self.mouse_mode = mode
         if self.mouse_mode_changed_callback:
             self.mouse_mode_changed_callback(mode)
+
+    def set_mouse_mode_buttons_enabled(self, enabled: bool):
+        """
+        Enable or disable the mouse mode buttons.
+        """
+        self.mouse_translate_btn.setEnabled(enabled)
+        self.mouse_rotate_btn.setEnabled(enabled)
+        self.mouse_interrogation_btn.setEnabled(enabled)
 
     def on_offset_change(self, axis_index, value):
         """


### PR DESCRIPTION
Removed none button

Added a save mouse state - that saves teh current state of the mouse mode

added method in main page that sets the mouse mode to none when the cut lines are clicked only on the image fusion tab, all other views are left untouched

disabled buttons - interrogation window, fine tune rotate, translate when cut lines are active