### PR TITLE
Add doc stings

### DIFF
--- a/src/Model/VTKEngine.py
+++ b/src/Model/VTKEngine.py
@@ -217,6 +217,22 @@ class VTKEngine:
         return True
 
     def load_moving(self, dicom_dir: str) -> bool:
+        """
+               Loads the moving image series from the specified DICOM directory and prepares it for registration.
+
+               This method reads the moving image DICOM files, computes the voxel-to-world transformation matrix,
+               and applies a pre-registration transform to align the moving image with the fixed image. It also
+               sets up the VTK pipeline for further processing and blending.
+
+               Args:
+                   dicom_dir: The directory containing the moving image DICOM files.
+
+               Returns:
+                   bool: True if the moving image was loaded successfully, False otherwise.
+
+               Raises:
+                   ValueError: If the DICOM directory does not contain valid image slices or has invalid orientation.
+               """
         self.moving_dir = dicom_dir
         try:
             slice_dir = prepare_dicom_slice_dir(dicom_dir)

--- a/src/View/ImageFusion/MovingImageLoader.py
+++ b/src/View/ImageFusion/MovingImageLoader.py
@@ -153,7 +153,6 @@ class MovingImageLoader(ImageLoader):
             progress_callback.emit(("Stopping", 85))
             return False
 
-        print("[DEBUG] About to return True from MovingImageLoader.load")
         return True
 
     def load_temp_rtss(self, path, progress_callback, interrupt_flag):

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -328,6 +328,14 @@ class UIMainWindow:
                 self.draw_roi.update_draw_roi_pixmaps()
 
     def toggle_cut_lines(self):
+        """
+                Toggles the display of cut lines across all DICOM and image fusion views.
+
+                This function enables or disables the cut lines in the axial, coronal, and sagittal views,
+                as well as in all image fusion views if present. It also manages the mouse mode and the
+                enabled state of mouse mode buttons in the translation menu for each view to ensure
+                consistent user interaction when cut lines are shown or hidden.
+                """
         cut_lines_enabled = (
                 self.dicom_axial_view.horizontal_view is not None and
                 self.dicom_axial_view.vertical_view is not None and
@@ -480,6 +488,16 @@ class UIMainWindow:
 
         # Define a callback that updates all three views for translation
         def update_all_views(offset):
+            """
+                        Updates the overlay offset for all image fusion views.
+
+                        This function propagates the given offset to all image fusion views,
+                        ensuring that the overlay is updated consistently across axial, sagittal,
+                        coronal, and single fusion views.
+
+                        Args:
+                            offset: A tuple or list representing the new (x, y, z) offset.
+                        """
             for view in [
                 self.image_fusion_single_view,
                 self.image_fusion_view_axial,
@@ -495,6 +513,16 @@ class UIMainWindow:
 
         # Define a callback that updates all three views for rotation
         def update_all_rotations(rotation_tuple):
+            """
+                        Updates the overlay rotation for all image fusion views.
+
+                        This function propagates the given rotation tuple to all image fusion views,
+                        ensuring that the overlay rotation is updated consistently across axial, sagittal,
+                        coronal, and single fusion views.
+
+                        Args:
+                            rotation_tuple: A tuple or list representing the new (rx, ry, rz) rotation in degrees.
+                        """
             for view in [
                 self.image_fusion_single_view,
                 self.image_fusion_view_axial,
@@ -509,6 +537,18 @@ class UIMainWindow:
 
         # --- Connect color pair change to all fusion views ---
         def propagate_color_pair_change(fixed_color, moving_color, coloring_enabled):
+            """
+                       Propagates color pair changes to all image fusion views.
+
+                       This function updates the color scheme for all image fusion views based on the
+                       selected fixed and moving colors and whether coloring is enabled. It ensures
+                       that the color settings remain consistent across all fusion views.
+
+                       Args:
+                           fixed_color: The color assigned to the fixed image.
+                           moving_color: The color assigned to the moving image.
+                           coloring_enabled: Boolean indicating if coloring is enabled.
+                       """
             for view in [
                 self.image_fusion_single_view,
                 self.image_fusion_view_axial,


### PR DESCRIPTION
Added doc strings as per Tims request

## Summary by Sourcery

Improve internal code documentation by adding comprehensive docstrings to key image view and loader functions and remove an unnecessary debug print statement.

Enhancements:
- Add descriptive docstrings to image view callback functions in MainPage to explain behavior, arguments, and usage.
- Add detailed docstring to VTKEngine.load_moving to outline its purpose, parameters, return value, and exceptions.

Chores:
- Remove leftover debug print from MovingImageLoader.load.